### PR TITLE
add badges for all artifact papers, less one

### DIFF
--- a/badges/badge_javascript.svg
+++ b/badges/badge_javascript.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.854263mm"
+   height="67.553268mm"
+   viewBox="0 0 70.854263 67.553268"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge_javascript.svg">
+  <defs
+     id="defs2">
+    <rect
+       x="43.945915"
+       y="126.40397"
+       width="31.089972"
+       height="14.777967"
+       id="rect1653" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.5"
+       segments="2"
+       displace_x="1.67;745093546"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.3899768"
+     inkscape:cx="94.581995"
+     inkscape:cy="134.35815"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="2554"
+     inkscape:window-height="1385"
+     inkscape:window-x="0"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-30.533587,-75.516223)">
+    <path
+       style="opacity:1;fill:#a0008c;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 100.6321,107.14551 c 0,1.8471 0.71355,5.28669 0.42555,7.05237 1.49372,2.07902 -2.525877,4.68378 -3.199754,6.47863 -2.160516,2.0996 -2.235979,2.48854 -2.80895,3.61187 -1.94776,1.44813 -0.186135,3.39748 -0.990351,4.60098 0.228048,2.30372 -3.725102,3.73346 -4.983843,4.98474 -2.427605,1.69163 -2.400639,2.57192 -3.30126,3.27165 -1.857271,1.873 -0.957076,1.74252 -2.190061,2.35593 -0.479739,1.0183 -6.435503,1.71893 -8.887891,2.10124 -3.465191,0.35137 -2.562104,-0.60865 -3.448246,-0.54163 -1.606602,0.12151 -2.644023,2.0082 -5.049165,2.0082 -1.8471,0 -3.513976,-1.96856 -5.278844,-2.27468 -1.488061,-2.09198 -3.318659,0.96249 -4.865111,0.47375 -1.895438,1.06495 -5.418393,-1.21684 -7.074431,-2.09731 -2.996833,-0.50742 -3.431797,-1.21453 -4.43618,-1.93915 -2.525785,-0.87672 -2.693205,-0.42283 -3.735742,-1.5318 -1.834336,-0.15382 -2.970979,-5.99073 -4.030412,-8.17455 -0.579196,-3.32743 -0.812409,-3.01042 -1.192338,-3.97064 -0.486364,-2.52051 -1.027705,-1.35308 -1.414027,-2.6915 -0.521449,-0.43953 -0.794289,-1.9867 -1.011428,-4.48832 -0.155735,-1.79419 -2.626029,-6.28343 -2.626029,-8.09659 0,-1.8471 0.467147,-5.44456 0.795912,-7.20413 0.513961,-2.961895 0.363089,-3.482042 0.713583,-4.590126 0.304083,-2.581482 0.968805,-1.307312 1.615909,-2.58709 0.979028,-0.542263 0.55179,-2.417292 1.989008,-4.155094 -0.148314,-0.419036 5.137441,-5.561352 7.238666,-7.206922 2.494002,-2.503562 0.599768,-1.256574 1.398899,-1.78063 0.823619,-1.255549 5.691123,-1.31871 7.701465,-2.088029 3.254969,0.325475 3.73614,-0.746577 4.88627,-1.167784 2.814379,-0.358387 3.856167,-0.181789 5.108414,-0.592412 1.517725,-0.497675 2.084927,-0.308592 4.355558,-0.308592 1.8471,0 2.424551,-1.192012 4.188534,-0.929658 1.05013,-0.987827 3.915564,3.131847 6.060397,3.925162 0.900445,2.766809 2.291167,-0.258065 3.71042,0.442012 1.156687,-0.538009 3.448497,-0.08187 5.130028,1.125951 1.53435,-0.836114 3.577888,0.540994 5.058214,2.164534 1.706404,-0.560136 4.899375,3.027056 6.033169,5.06391 2.973269,1.021006 -0.22679,3.151953 0.218161,4.726517 -1.133359,1.884161 2.679267,3.246767 3.102642,4.945029 2.175834,1.637149 0.428044,1.765206 0.290954,3.491072 -0.147048,1.85116 0.50231,3.92847 0.50231,5.59309 z" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.252355"
+       id="rect903"
+       width="20.165871"
+       height="20.165871"
+       x="-7.9582539"
+       y="118.57958"
+       transform="rotate(-30)" />
+    <circle
+       style="fill:#a0008c;fill-opacity:1;stroke-width:0.198497"
+       id="path901"
+       cx="66.199608"
+       cy="110.29929"
+       r="8.7086334" />
+    <text
+       xml:space="preserve"
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+       transform="matrix(0.75022721,0,0,0.75022721,18.251027,23.417549)"><tspan
+         x="53.779297"
+         y="119.53584"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">artifacts available</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="3.5441139"
+       sodipodi:end="5.8807857"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 40.15645,103.55094 A 27.525377,27.525377 0 0 1 65.48357,86.808332 27.525377,27.525377 0 0 1 90.808653,103.55402" />
+    <text
+       xml:space="preserve"
+       id="text1651"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;white-space:pre;fill:#ffffff;fill-opacity:1"><textPath
+         xlink:href="#path10-6-78"
+         id="textPath3154">but they're in javascript</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6-78"
+       sodipodi:type="arc"
+       sodipodi:cx="-65.294685"
+       sodipodi:cy="111.29484"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="0.025349257"
+       sodipodi:end="3.1183644"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M -37.778151,111.99251 A 27.525377,27.525377 0 0 1 -65.323876,138.8202 27.525377,27.525377 0 0 1 -92.812637,111.93415"
+       transform="scale(-1,1)" />
+  </g>
+</svg>

--- a/badges/badge_literate.svg
+++ b/badges/badge_literate.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.854263mm"
+   height="67.553268mm"
+   viewBox="0 0 70.854263 67.553268"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge_literate.svg">
+  <defs
+     id="defs2">
+    <rect
+       x="43.945915"
+       y="126.40397"
+       width="31.089972"
+       height="14.777967"
+       id="rect1653" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.5"
+       segments="2"
+       displace_x="1.67;745093546"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.3899768"
+     inkscape:cx="94.581995"
+     inkscape:cy="134.35815"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="2554"
+     inkscape:window-height="1385"
+     inkscape:window-x="0"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-30.533587,-75.516223)">
+    <path
+       style="opacity:1;fill:#17718c;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 100.6321,107.14551 c 0,1.8471 0.71355,5.28669 0.42555,7.05237 1.49372,2.07902 -2.525877,4.68378 -3.199754,6.47863 -2.160516,2.0996 -2.235979,2.48854 -2.80895,3.61187 -1.94776,1.44813 -0.186135,3.39748 -0.990351,4.60098 0.228048,2.30372 -3.725102,3.73346 -4.983843,4.98474 -2.427605,1.69163 -2.400639,2.57192 -3.30126,3.27165 -1.857271,1.873 -0.957076,1.74252 -2.190061,2.35593 -0.479739,1.0183 -6.435503,1.71893 -8.887891,2.10124 -3.465191,0.35137 -2.562104,-0.60865 -3.448246,-0.54163 -1.606602,0.12151 -2.644023,2.0082 -5.049165,2.0082 -1.8471,0 -3.513976,-1.96856 -5.278844,-2.27468 -1.488061,-2.09198 -3.318659,0.96249 -4.865111,0.47375 -1.895438,1.06495 -5.418393,-1.21684 -7.074431,-2.09731 -2.996833,-0.50742 -3.431797,-1.21453 -4.43618,-1.93915 -2.525785,-0.87672 -2.693205,-0.42283 -3.735742,-1.5318 -1.834336,-0.15382 -2.970979,-5.99073 -4.030412,-8.17455 -0.579196,-3.32743 -0.812409,-3.01042 -1.192338,-3.97064 -0.486364,-2.52051 -1.027705,-1.35308 -1.414027,-2.6915 -0.521449,-0.43953 -0.794289,-1.9867 -1.011428,-4.48832 -0.155735,-1.79419 -2.626029,-6.28343 -2.626029,-8.09659 0,-1.8471 0.467147,-5.44456 0.795912,-7.20413 0.513961,-2.961895 0.363089,-3.482042 0.713583,-4.590126 0.304083,-2.581482 0.968805,-1.307312 1.615909,-2.58709 0.979028,-0.542263 0.55179,-2.417292 1.989008,-4.155094 -0.148314,-0.419036 5.137441,-5.561352 7.238666,-7.206922 2.494002,-2.503562 0.599768,-1.256574 1.398899,-1.78063 0.823619,-1.255549 5.691123,-1.31871 7.701465,-2.088029 3.254969,0.325475 3.73614,-0.746577 4.88627,-1.167784 2.814379,-0.358387 3.856167,-0.181789 5.108414,-0.592412 1.517725,-0.497675 2.084927,-0.308592 4.355558,-0.308592 1.8471,0 2.424551,-1.192012 4.188534,-0.929658 1.05013,-0.987827 3.915564,3.131847 6.060397,3.925162 0.900445,2.766809 2.291167,-0.258065 3.71042,0.442012 1.156687,-0.538009 3.448497,-0.08187 5.130028,1.125951 1.53435,-0.836114 3.577888,0.540994 5.058214,2.164534 1.706404,-0.560136 4.899375,3.027056 6.033169,5.06391 2.973269,1.021006 -0.22679,3.151953 0.218161,4.726517 -1.133359,1.884161 2.679267,3.246767 3.102642,4.945029 2.175834,1.637149 0.428044,1.765206 0.290954,3.491072 -0.147048,1.85116 0.50231,3.92847 0.50231,5.59309 z" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.252355"
+       id="rect903"
+       width="20.165871"
+       height="20.165871"
+       x="-7.9582539"
+       y="118.57958"
+       transform="rotate(-30)" />
+    <circle
+       style="fill:#17718c;fill-opacity:1;stroke-width:0.198497"
+       id="path901"
+       cx="66.199608"
+       cy="110.29929"
+       r="8.7086334" />
+    <text
+       xml:space="preserve"
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+       transform="matrix(0.75022721,0,0,0.75022721,18.251027,23.417549)"><tspan
+         x="53.779297"
+         y="119.53584"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">artifacts available</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="3.5441139"
+       sodipodi:end="5.8807857"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 40.15645,103.55094 A 27.525377,27.525377 0 0 1 65.48357,86.808332 27.525377,27.525377 0 0 1 90.808653,103.55402" />
+    <text
+       xml:space="preserve"
+       id="text1651"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;white-space:pre;fill:#ffffff;fill-opacity:1"><textPath
+         xlink:href="#path10-6-7"
+         id="textPath3232">within this very paper!</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6-7"
+       sodipodi:type="arc"
+       sodipodi:cx="-66.164482"
+       sodipodi:cy="111.39729"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="0.11167074"
+       sodipodi:end="3.025559"
+       sodipodi:arc-type="arc"
+       d="M -38.810552,114.46469 A 27.525377,27.525377 0 0 1 -66.104437,138.9226 27.525377,27.525377 0 0 1 -93.504769,114.584"
+       sodipodi:open="true"
+       transform="scale(-1,1)" />
+  </g>
+</svg>

--- a/badges/badge_netlogo.svg
+++ b/badges/badge_netlogo.svg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.854263mm"
+   height="67.553268mm"
+   viewBox="0 0 70.854263 67.553268"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge_netlogo.svg">
+  <defs
+     id="defs2">
+    <rect
+       x="43.945915"
+       y="126.40397"
+       width="31.089972"
+       height="14.777967"
+       id="rect1653" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.5"
+       segments="2"
+       displace_x="1.67;745093546"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.3899768"
+     inkscape:cx="94.581995"
+     inkscape:cy="134.35815"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="2554"
+     inkscape:window-height="1385"
+     inkscape:window-x="0"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-30.533587,-75.516223)">
+    <path
+       style="opacity:1;fill:#d8718c;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 100.6321,107.14551 c 0,1.8471 0.71355,5.28669 0.42555,7.05237 1.49372,2.07902 -2.525877,4.68378 -3.199754,6.47863 -2.160516,2.0996 -2.235979,2.48854 -2.80895,3.61187 -1.94776,1.44813 -0.186135,3.39748 -0.990351,4.60098 0.228048,2.30372 -3.725102,3.73346 -4.983843,4.98474 -2.427605,1.69163 -2.400639,2.57192 -3.30126,3.27165 -1.857271,1.873 -0.957076,1.74252 -2.190061,2.35593 -0.479739,1.0183 -6.435503,1.71893 -8.887891,2.10124 -3.465191,0.35137 -2.562104,-0.60865 -3.448246,-0.54163 -1.606602,0.12151 -2.644023,2.0082 -5.049165,2.0082 -1.8471,0 -3.513976,-1.96856 -5.278844,-2.27468 -1.488061,-2.09198 -3.318659,0.96249 -4.865111,0.47375 -1.895438,1.06495 -5.418393,-1.21684 -7.074431,-2.09731 -2.996833,-0.50742 -3.431797,-1.21453 -4.43618,-1.93915 -2.525785,-0.87672 -2.693205,-0.42283 -3.735742,-1.5318 -1.834336,-0.15382 -2.970979,-5.99073 -4.030412,-8.17455 -0.579196,-3.32743 -0.812409,-3.01042 -1.192338,-3.97064 -0.486364,-2.52051 -1.027705,-1.35308 -1.414027,-2.6915 -0.521449,-0.43953 -0.794289,-1.9867 -1.011428,-4.48832 -0.155735,-1.79419 -2.626029,-6.28343 -2.626029,-8.09659 0,-1.8471 0.467147,-5.44456 0.795912,-7.20413 0.513961,-2.961895 0.363089,-3.482042 0.713583,-4.590126 0.304083,-2.581482 0.968805,-1.307312 1.615909,-2.58709 0.979028,-0.542263 0.55179,-2.417292 1.989008,-4.155094 -0.148314,-0.419036 5.137441,-5.561352 7.238666,-7.206922 2.494002,-2.503562 0.599768,-1.256574 1.398899,-1.78063 0.823619,-1.255549 5.691123,-1.31871 7.701465,-2.088029 3.254969,0.325475 3.73614,-0.746577 4.88627,-1.167784 2.814379,-0.358387 3.856167,-0.181789 5.108414,-0.592412 1.517725,-0.497675 2.084927,-0.308592 4.355558,-0.308592 1.8471,0 2.424551,-1.192012 4.188534,-0.929658 1.05013,-0.987827 3.915564,3.131847 6.060397,3.925162 0.900445,2.766809 2.291167,-0.258065 3.71042,0.442012 1.156687,-0.538009 3.448497,-0.08187 5.130028,1.125951 1.53435,-0.836114 3.577888,0.540994 5.058214,2.164534 1.706404,-0.560136 4.899375,3.027056 6.033169,5.06391 2.973269,1.021006 -0.22679,3.151953 0.218161,4.726517 -1.133359,1.884161 2.679267,3.246767 3.102642,4.945029 2.175834,1.637149 0.428044,1.765206 0.290954,3.491072 -0.147048,1.85116 0.50231,3.92847 0.50231,5.59309 z" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.252355"
+       id="rect903"
+       width="20.165871"
+       height="20.165871"
+       x="-7.9582539"
+       y="118.57958"
+       transform="rotate(-30)" />
+    <circle
+       style="fill:#d8718c;fill-opacity:1;stroke-width:0.198497"
+       id="path901"
+       cx="66.199608"
+       cy="110.29929"
+       r="8.7086334" />
+    <text
+       xml:space="preserve"
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+       transform="matrix(0.75022721,0,0,0.75022721,18.251027,23.417549)"><tspan
+         x="53.779297"
+         y="119.53584"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">artifacts available</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="3.5441139"
+       sodipodi:end="5.8807857"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 40.15645,103.55094 A 27.525377,27.525377 0 0 1 65.48357,86.808332 27.525377,27.525377 0 0 1 90.808653,103.55402" />
+    <text
+       xml:space="preserve"
+       id="text1651"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;white-space:pre;fill:#ffffff;fill-opacity:1;"><textPath
+         xlink:href="#path10-6-7"
+         id="textPath3232"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.17361px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">tbh hadn't heard of netlogo</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6-7"
+       sodipodi:type="arc"
+       sodipodi:cx="-66.164482"
+       sodipodi:cy="111.39729"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="0.11167074"
+       sodipodi:end="3.025559"
+       sodipodi:arc-type="arc"
+       d="M -38.810552,114.46469 A 27.525377,27.525377 0 0 1 -66.104437,138.9226 27.525377,27.525377 0 0 1 -93.504769,114.584"
+       sodipodi:open="true"
+       transform="scale(-1,1)" />
+  </g>
+</svg>

--- a/badges/badge_pagenumbers.svg
+++ b/badges/badge_pagenumbers.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.843781mm"
+   height="66.955322mm"
+   viewBox="0 0 70.84378 66.955322"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge_pagenumbers.svg">
+  <defs
+     id="defs2">
+    <rect
+       x="43.945915"
+       y="126.40397"
+       width="31.089972"
+       height="14.777967"
+       id="rect1653" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.5"
+       segments="2"
+       displace_x="1.67;2060941883"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.3899768"
+     inkscape:cx="141.8594"
+     inkscape:cy="131.9646"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1349"
+     inkscape:window-height="1385"
+     inkscape:window-x="1205"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-30.53856,-76.149516)">
+    <path
+       style="opacity:1;fill:#cd7200;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 101.23228,107.82082 c 0,1.8471 0.10755,4.66853 -0.18044,6.43421 1.49097,2.11736 -2.507643,4.62031 -3.171508,6.39756 -2.153967,2.08436 -2.249022,2.53343 -2.82625,3.6662 -1.952126,1.46564 0.04627,2.66552 -0.753255,3.86325 0.336434,1.75933 -3.855704,4.64912 -5.303602,6.05442 -2.225054,2.18413 -2.595568,1.88669 -3.430387,2.52525 -2.172458,1.32007 -1.971753,3.02264 -3.178687,3.65754 -1.291641,2.24534 -5.340135,1.36216 -7.258535,1.58142 -3.193366,0.17616 -3.288148,-0.53786 -4.367714,-0.54719 -1.517349,-0.0131 -2.668487,1.65136 -5.021212,1.65136 -1.8471,0 -2.704254,-1.70121 -4.460888,-2.00797 -0.934864,-1.87019 -4.282202,1.00568 -6.061657,0.39432 -2.237154,1.23365 -5.062736,-1.24515 -6.604941,-2.10547 -2.895925,-0.57091 -3.476377,-1.27482 -4.485507,-2.04229 -2.521834,-0.88892 -2.470161,-0.46139 -3.483198,-1.59548 -1.630792,-0.18075 -4.01981,-5.75088 -5.057907,-7.97123 -1.677314,-2.99541 -0.208274,-2.77007 -0.527555,-3.73135 0.09907,-2.42647 -0.250546,-1.67363 -0.575654,-3.17262 0.2796,-0.5 -0.775564,-2.02153 -1.120481,-4.49963 -0.253475,-1.82111 -2.824342,-6.44668 -2.824342,-8.21182 0,-1.8471 0.655955,-5.40068 0.984631,-7.15814 0.701527,-2.911179 -0.198376,-3.233393 0.147445,-4.333886 -0.210992,-2.491608 0.949698,-1.442228 1.690127,-2.840675 0.90848,-0.427256 0.958679,-2.122973 2.489957,-3.889284 0.150845,-0.02387 5.494854,-5.158326 7.595766,-6.806708 2.771758,-2.141213 0.577723,-1.287017 1.33417,-1.805977 0.79177,-1.323204 3.520602,-0.110429 5.399001,-0.93197 1.836172,1.253991 5.789032,-1.364468 7.738618,-2.203854 3.370728,-0.213155 3.446865,-0.589567 4.41905,-1.093941 1.499038,-0.777707 2.367235,-0.839034 4.501543,-0.839034 1.8471,0 1.888506,-0.253441 3.643461,0.01503 0.565537,-0.03584 4.388021,3.280562 6.579135,4.086779 1.129994,2.827544 2.22985,-0.309763 3.510383,0.295787 1.296391,-0.5365 3.254934,-0.1356 4.844154,0.945356 1.504525,-0.783064 3.785804,0.498117 5.239222,2.012249 1.94458,-0.523788 4.590028,2.369885 5.685253,4.273783 2.817775,0.710222 0.171159,4.38803 0.648689,6.166116 -0.976605,2.571893 2.155242,2.656708 2.496353,3.997359 1.853982,1.644212 0.689212,1.749594 0.633362,3.466716 -0.0588,1.80792 1.1134,4.5303 1.1134,6.30381 z" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.252355"
+       id="rect903"
+       width="20.165871"
+       height="20.165871"
+       x="-7.9582539"
+       y="118.57958"
+       transform="rotate(-30)" />
+    <circle
+       style="fill:#cd7200;fill-opacity:1;stroke-width:0.198497"
+       id="path901"
+       cx="66.199608"
+       cy="110.29929"
+       r="8.7086334" />
+    <text
+       xml:space="preserve"
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+       transform="matrix(0.75022721,0,0,0.75022721,18.251027,23.417549)"><tspan
+         x="53.779297"
+         y="119.53584"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">forgot to remove page numbers</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="26.360748"
+       sodipodi:ry="26.360748"
+       sodipodi:start="2.6280987"
+       sodipodi:end="0.52378609"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="m 42.5208,127.28273 a 26.360748,26.360748 0 0 1 6.154419,-33.257262 26.360748,26.360748 0 0 1 33.821474,0.174049 26.360748,26.360748 0 0 1 5.811811,33.318843" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6-7"
+       sodipodi:type="arc"
+       sodipodi:cx="-65.016327"
+       sodipodi:cy="111.24743"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="1.0300903"
+       sodipodi:end="2.1527822"
+       sodipodi:arc-type="arc"
+       d="m -50.847875,134.84619 a 27.525377,27.525377 0 0 1 -29.29871,-0.60481"
+       sodipodi:open="true"
+       transform="scale(-1,1)" />
+  </g>
+</svg>

--- a/badges/badge_unavailable.svg
+++ b/badges/badge_unavailable.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.925415mm"
+   height="68.939262mm"
+   viewBox="0 0 70.925415 68.939262"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge.pdf">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.458302"
+     inkscape:cx="139.42205"
+     inkscape:cy="184.13973"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1530"
+     inkscape:window-height="1385"
+     inkscape:window-x="1024"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-30.564157,-76.052492)">
+    <path
+       style="fill:#008b00;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 100.24526,106.94659 c 0,1.8471 1.07853,5.65086 0.79053,7.41653 1.48086,2.18913 -1.081567,5.52856 -1.726153,7.27191 -0.719993,3.00398 -2.013206,2.80903 -2.572045,3.87492 -1.782024,1.86109 -0.0042,2.60505 -0.852088,3.7687 0.169244,1.81564 -4.32118,4.96358 -6.038448,6.36819 -2.360869,2.30527 -2.256933,2.29039 -3.161107,2.85352 -1.925544,1.83545 -1.314443,1.97773 -2.79235,2.47693 -0.505642,1.12484 -5.251982,3.20505 -7.814635,3.32041 -2.559107,2.29708 -4.468366,-1.79371 -6.0956,-2.38513 -1.556352,-0.56565 -2.817921,1.6503 -4.541764,1.6503 -1.847101,0 -2.543563,-1.5936 -4.294813,-1.9086 -0.822754,-1.77609 -4.974337,0.70281 -6.792216,0.0474 -2.63876,1.02571 -4.451851,-1.07765 -5.807913,-1.83257 -2.753249,-0.56244 -3.620781,-1.0144 -4.68062,-1.83994 -2.613551,-0.62493 -3.147115,-0.66593 -4.198559,-1.92709 -2.097937,-0.22379 -4.103348,-5.58338 -5.027761,-7.82985 -1.939111,-2.88717 -0.08578,-3.07621 -0.356274,-4.16317 0.315682,-2.4947 0.235678,-1.84877 0.02017,-3.35 0.647442,-0.68061 -0.628208,-2.02338 -0.962988,-4.42627 -0.254246,-1.82486 -2.77647,-6.24108 -2.77647,-8.01255 0,-1.8471 1.197393,-5.15173 1.525607,-6.91205 1.248025,-2.689956 -0.202159,-3.319932 0.148574,-4.450319 -0.242396,-2.480767 0.905929,-1.41275 1.60619,-2.786332 0.866894,-0.454829 0.545305,-2.456193 2.004854,-4.222862 -0.198387,-0.412808 5.288507,-5.36219 7.370156,-7.017927 2.648267,-2.304496 0.749426,-1.719144 1.521376,-2.244984 0.898185,-1.691175 5.096649,-0.976353 6.927262,-1.717921 3.056472,0.520349 3.998316,-0.52355 5.276092,-1.012215 2.850478,-0.01039 3.897788,-0.273958 5.175825,-0.789686 1.491129,-0.601717 2.947901,-0.932332 5.144065,-0.932332 1.8471,0 1.912156,-0.348098 3.659455,-0.07919 0.589499,-0.129203 4.302295,3.270791 6.47753,4.085007 1.061276,2.820428 2.21659,-0.288792 3.496067,0.330108 1.265103,-0.525019 3.084551,-0.08646 4.656481,1.009561 1.360293,-0.734458 3.681433,0.51068 5.133892,2.057095 1.832547,-0.549304 4.677957,2.703403 5.770994,4.627388 2.862962,0.913801 0.679048,4.467666 1.134269,6.094694 -0.382722,2.761064 1.937694,2.439305 2.200932,3.638488 1.664562,1.726878 0.888702,1.852116 0.765082,3.596304 -0.12495,1.76304 -0.3136,3.53884 -0.3136,5.3535 z" />
+    <g
+       id="g909"
+       transform="matrix(0.75022721,0,0,0.75022721,12.478352,36.60735)">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.336371"
+         id="rect903"
+         width="26.879684"
+         height="26.879684"
+         x="-0.61467803"
+         y="107.48412"
+         transform="rotate(-30)" />
+      <circle
+         style="fill:#008a00;fill-opacity:1;stroke-width:0.264583"
+         id="path901"
+         cx="71.606651"
+         cy="98.226158"
+         r="11.607995" />
+      <text
+         xml:space="preserve"
+         id="text857"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+         transform="translate(7.6945692,-17.581075)"><tspan
+           x="53.779297"
+           y="119.53584"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">artifacts unavailable</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="3.397684"
+       sodipodi:end="6.0277289"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 38.854191,107.3615 A 27.525377,27.525377 0 0 1 65.490634,86.808334 27.525377,27.525377 0 0 1 92.114021,107.3784" />
+  </g>
+</svg>

--- a/badges/badge_unusable.svg
+++ b/badges/badge_unusable.svg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="70.27832mm"
+   height="68.040543mm"
+   viewBox="0 0 70.27832 68.040542"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="badge_unusable.svg">
+  <defs
+     id="defs2">
+    <rect
+       x="43.945915"
+       y="126.40397"
+       width="31.089972"
+       height="14.777967"
+       id="rect1653" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect885"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="4.669"
+       segments="2"
+       displace_x="1.57;2147483646"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;1881786829"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <rect
+       x="77.446732"
+       y="48.420933"
+       width="49.29604"
+       height="16.043911"
+       id="rect852" />
+    <rect
+       x="53.780128"
+       y="108.44247"
+       width="20.266811"
+       height="14.2308"
+       id="rect859" />
+    <inkscape:path-effect
+       effect="roughen"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       method="size"
+       max_segment_size="5.5"
+       segments="2"
+       displace_x="1.67;1479138896"
+       displace_y="1.77;2147483646"
+       global_randomize="2.4;2147483646"
+       handles="along"
+       shift_nodes="true"
+       fixed_displacement="true"
+       spray_tool_friendly="true" />
+    <inkscape:path-effect
+       effect="gears"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       teeth="21"
+       phi="5"
+       min_radius="5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.3899768"
+     inkscape:cx="116.59762"
+     inkscape:cy="136.36197"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1416"
+     inkscape:window-height="1385"
+     inkscape:window-x="1138"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-31.096706,-74.986046)">
+    <path
+       style="opacity:1;fill:#cd0000;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path10"
+       inkscape:path-effect="#path-effect14"
+       sodipodi:type="arc"
+       sodipodi:cx="66.243134"
+       sodipodi:cy="108.61794"
+       sodipodi:rx="33.44471"
+       sodipodi:ry="33.44471"
+       d="m 101.33111,108.07545 c 0,1.8471 0.003,4.45797 -0.28501,6.22364 1.48763,2.14675 -2.51525,4.5253 -3.171309,6.28882 -2.174201,2.03657 -2.272242,2.62264 -2.857869,3.7717 -1.955606,1.50326 0.04643,2.63264 -0.741552,3.81659 0.322907,1.75619 -3.008977,5.14918 -4.449946,6.55303 -1.491206,2.79017 -2.932508,2.17184 -3.913293,2.85823 -2.310678,1.37406 -1.022346,1.59923 -2.278968,2.16002 -0.528115,0.92827 -6.506043,1.45802 -8.952961,1.80115 -3.469593,0.20835 -2.503803,-0.64576 -3.380755,-0.56928 -1.63611,0.14267 -2.94957,2.04724 -5.333298,2.04724 -1.8471,0 -2.062261,-1.02144 -3.822954,-1.32679 -0.547318,-1.23345 -4.988211,1.08814 -7.016448,0.33621 -2.427799,1.40838 -4.828516,-0.4727 -6.374235,-1.39076 -2.897419,0.11824 -4.228996,-1.59737 -5.427413,-2.63911 -2.77173,-0.88705 -2.690249,-0.67444 -3.652207,-1.91015 -1.832501,-0.30106 -4.074913,-5.73041 -4.99259,-8.01693 -1.950413,-2.87809 -0.73623,-3.22841 -1.002253,-4.27795 -0.359384,-2.63979 -0.0044,-1.6228 -0.146612,-3.01648 0.419866,-0.63891 -0.269659,-2.07079 -0.412511,-4.46339 -0.109365,-1.83172 -2.02222,-7.39304 -2.02222,-9.16128 0,-1.8471 0.459748,-5.42264 0.778376,-7.162071 0.503717,-2.92836 -0.241212,-3.154051 0.09513,-4.233317 -0.243328,-2.441985 1.073655,-1.430491 1.814363,-2.810898 1.020989,-0.368426 0.689841,-2.29701 2.189465,-3.991371 -0.09151,-0.270105 5.270731,-5.162785 7.372213,-6.722219 2.577148,-2.255236 0.606512,-1.255039 1.3712,-1.738519 0.829725,-1.273135 4.210432,-0.05482 6.125044,-0.77941 2.324868,1.299136 5.119246,-0.955149 6.803923,-1.634234 3.149314,-0.152756 3.505339,-0.365255 4.56709,-0.873669 1.490309,-0.713625 2.685614,-1.006624 4.819921,-1.006624 1.847101,0 2.573727,-1.309979 4.325179,-1.040601 1.166441,-1.104233 4.252528,3.172557 6.339955,3.975059 1.180824,2.759131 2.624535,-0.332199 3.895311,0.313535 1.642026,-0.579742 3.094818,-0.01831 4.607129,1.111948 1.477636,-0.623979 3.299308,0.601054 4.729248,2.27718 1.461533,-0.498063 4.729941,2.588528 5.837155,4.748918 2.890472,0.598065 -0.432373,3.675206 -0.0057,5.56509 -1.487588,1.897331 2.517904,3.243422 2.929574,4.926683 2.142535,1.643052 0.630595,1.763805 0.535795,3.45902 -0.10535,1.88383 1.10404,4.87827 1.10404,6.53099 z" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:0.252355"
+       id="rect903"
+       width="20.165871"
+       height="20.165871"
+       x="-7.9582539"
+       y="118.57958"
+       transform="rotate(-30)" />
+    <circle
+       style="fill:#cd0000;fill-opacity:1;stroke-width:0.198497"
+       id="path901"
+       cx="66.199608"
+       cy="110.29929"
+       r="8.7086334" />
+    <text
+       xml:space="preserve"
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.2889px;line-height:1.25;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;white-space:pre;shape-inside:url(#rect859);fill:#ffffff;fill-opacity:1;stroke:none;"
+       transform="matrix(0.75022721,0,0,0.75022721,18.251027,23.417549)"><tspan
+         x="53.779297"
+         y="119.53584"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.9944px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">ach</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       id="text850"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;white-space:pre;fill:#000000;fill-opacity:1;stroke:none;stroke-opacity:1"><textPath
+         xlink:href="#path10-6"
+         id="textPath889"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1">artifacts evaluated</textPath></text>
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6"
+       sodipodi:type="arc"
+       sodipodi:cx="65.481895"
+       sodipodi:cy="114.33371"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="3.5123987"
+       sodipodi:end="5.9260053"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 39.827265,104.35943 A 27.525377,27.525377 0 0 1 65.669425,86.808971 27.525377,27.525377 0 0 1 91.27005,104.70991" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.20566;stroke-opacity:1"
+       id="path10-6-7"
+       sodipodi:type="arc"
+       sodipodi:cx="-65.016327"
+       sodipodi:cy="111.24743"
+       sodipodi:rx="27.525377"
+       sodipodi:ry="27.525377"
+       sodipodi:start="1.0300903"
+       sodipodi:end="2.1527822"
+       sodipodi:arc-type="arc"
+       d="m -50.847875,134.84619 a 27.525377,27.525377 0 0 1 -29.29871,-0.60481"
+       sodipodi:open="true"
+       transform="scale(-1,1)" />
+    <text
+       xml:space="preserve"
+       id="text1651"
+       style="font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;white-space:pre"><textPath
+         xlink:href="#path10-6-7"
+         id="textPath1668"><tspan
+           id="tspan1655"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.40833px;font-family:Birbaslo;-inkscape-font-specification:'Birbaslo, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1">unusable</tspan></textPath></text>
+  </g>
+</svg>

--- a/papers.tex
+++ b/papers.tex
@@ -7,6 +7,8 @@
 \addproceedings{Blindsight is also 2021}
 
 \newcommand{\link}[2][]{\vspace{-1in} {\scriptsize #1 \url{#2}} \raisebox{-0.5\height}{\includegraphics[height=0.75in]{participation}}}
+\newcommand{\badge}[1]{\includegraphics[height=0.75in]{badges/badge_#1}}
+\newcommand{\badges}[1]{\vspace{-1in} \raisebox{-0.5\height}{#1}}
 
 \addtrack
     {}{Fun(?) and Games Track}
@@ -16,7 +18,7 @@
     {Keywords: Almost Monopoly, AlphaX, Artificial Neural Networks, Board Games, Deep Learning, Games With Boards, Machine Learning, Machine Learning That Matters, Reinforcement Learning, Tree Search}
     {SIGBOVIK_2021_paper_5}
     {0cm}
-    {}
+    {\badges{\badge{unusable}}}
 \addpaper
     {Demystifying the Mortal Kombat Song}
     {J Devi and Chai-Tea Latte}
@@ -48,7 +50,7 @@
     {Keywords: solitaire, klondike, cards}
     {SIGBOVIK_2021_paper_27}
     {0cm}
-    {}
+    {\badges{\badge{javascript}}}
 \addpaper
     {Opening Moves in 1830: Strategy in Resolving the N-way Prisoner’s Dilemma}
     {Philihp Busby and Daniel Ribeiro E Sousa}
@@ -148,7 +150,7 @@
     {Keywords: types, databases, constraints, texting, machine translation, typescript}
     {SIGBOVIK_2021_paper_21}
     {0cm}
-    {}
+    {\badges{\badge{unavailable}}}
 \addpaper
     {Lowestcase and uppestcase letters: Advances in derp learning}
     {Tom Murphy VII}
@@ -162,7 +164,7 @@
     {Keywords: dependent stringly typed programming, best practices, agda}
     {SIGBOVIK_2021_paper_34}
     {0cm}
-    {}
+    {\badges{\badge{literate}}}
 \addpaper
     {Yet Another Lottery Ticket Hypothesis}
     {Aman Madaan and Gary Yao}
@@ -273,14 +275,14 @@
     {Keywords: damn, forgot, again, deadlines}
     {SIGBOVIK_2021_paper_7}
     {0cm}
-    {}
+    {\badges{\badge{pagenumbers}}}
 \addpaper
     {NetPlop: A moderately-featured presentation editor built in NetLogo}
     {Patrick Steinmann}
     {Keywords: agent-based slideshows, slide-based models, singularity}
     {SIGBOVIK_2021_paper_37}
     {0cm}
-    {}
+    {\badges{\badge{netlogo}}}
 
 \addtrack{}{(Meta)physics}
 \addpaper
@@ -296,7 +298,7 @@
     {Keywords: syntax tree, pyramids, compilation, horizontal gene transfer, sorting, code golf}
     {SIGBOVIK_2021_paper_31}
     {0cm}
-    {}
+    {\badges{needs a badge}}
 \addpaper
     {On the fundamental impossibility of refining the Theory of Everything by empirical observations: a computational theoretic perspective}
     {Zikuan Wang}


### PR DESCRIPTION
All the papers that have something that resembled artifacts now have badges, except one; some of them could be more creative, but, well, that's life. I would like suggestions for the one that's missing, though! (The macro language for Pyramid Scheme)